### PR TITLE
Updated the alert show and edit pages

### DIFF
--- a/app/views/alerts/edit.html.erb
+++ b/app/views/alerts/edit.html.erb
@@ -6,7 +6,7 @@
         <div class="form-input">
 
           <%= f.input :category,
-                as: :select,
+                as: :radio_buttons,
                 collection: ["Vandalism", "Littering", "Broken Object", "Transportation", "New Idea", "Other"], selected: { value: @alert.category }%>
             <%= f.input :title, input_html: { value: @alert.title } %>
             <%= f.input :description, input_html: { value: @alert.description } %>

--- a/app/views/alerts/show.html.erb
+++ b/app/views/alerts/show.html.erb
@@ -38,7 +38,11 @@
               <br>Category: <%= @alert.category %>
               <p class="pe-5 mb-2"><%= @alert.description %>
               <br>
-              <br>Added by: <%= @alert.creator.first_name %> on <%= @alert.created_at.strftime('%d %b %Y') %></p>
+              <% if @alert.creator == current_user %>
+                <br>Added by: You on <%= @alert.created_at.strftime('%d %b %Y') %></p>
+              <% else %>
+                <br>Added by: <%= @alert.creator.first_name %> on <%= @alert.created_at.strftime('%d %b %Y') %></p>
+               <% end %>
               <br>Status: <%= @alert.status %></p>
               <br>
               <%# Upvotes %>


### PR DESCRIPTION
Updated:
- current_user logic to display who created the alert.
- Changed the edit form category field into radio buttons like the new alert form.

<img width="212" alt="Screenshot 2022-11-29 at 14 55 28" src="https://user-images.githubusercontent.com/58528404/204635264-9a77582e-2b30-4fa5-abc6-1d76f1b34a0f.png">
<img width="260" alt="Screenshot 2022-11-29 at 14 49 52" src="https://user-images.githubusercontent.com/58528404/204635267-28ea76df-8010-4e90-bba3-a0ce2b786f7d.png">
<img width="324" alt="Screenshot 2022-11-29 at 14 49 41" src="https://user-images.githubusercontent.com/58528404/204635269-07a4a9b2-1315-4ed4-a080-6fdeed59acb6.png">
