### PR TITLE
Updated site to Cloudinary & other image fixes

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -107,7 +107,7 @@ export default class extends Controller {
         <div class="listing card shadow-sm d-flex flex-row">
           <img class="me-3"
                src="${alert.photos[0].url}"
-               style="width:80px; height:80px; border-radius:50%;">
+               style="width:80px; height:80px; border-radius:50%; object-fit:fill;">
           <div class="listing-details">
             <a href="${alertUrl.value}/${alert.id}">${alert.address}</a><br>
             <strong>${alert.title}</strong>
@@ -122,7 +122,7 @@ export default class extends Controller {
     alertsHeading.innerHTML= `
       <h5 id="alerts-heading">Alerts in this area
       <a data-action="click->alerts#showAlertList"
-      class="fs-4 toggle">
+      class="fs-3 toggle">
       <i class="fa-solid fa-circle-chevron-down"></i></a></h5>`
   }
 

--- a/app/views/alerts/show.html.erb
+++ b/app/views/alerts/show.html.erb
@@ -5,12 +5,13 @@
         <div class="alert-container">
           <div class="carousel-container">
             <div id="carouselExampleIndicators" class="carousel slide" data-bs-ride="true">
-
-              <div class="carousel-indicators">
-                <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
-                <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1" aria-label="Slide 2"></button>
-                <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="2" aria-label="Slide 3"></button>
-              </div>
+              <% if @alert.photos.size > 1 %>
+                <div class="carousel-indicators">
+                  <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+                  <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1" aria-label="Slide 2"></button>
+                  <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="2" aria-label="Slide 3"></button>
+                </div>
+              <% end %>
               <div class="carousel-inner rounded-4">
                 <% @alert.photos.each do |photo| %>
                   <% if photo == @alert.photos[0] %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -12,7 +12,7 @@
       <%= link_to "Send an alert", alerts_path, class: "fs-4 p-3 fw-bold btn btn-primary text-white rounded-pill" %>
     </div>
     <div class="col-12 col-lg-4 phone-container">
-      <%= image_tag "smartphone_mockup.png", height: 650 %>
+      <%= cl_image_tag("c9tro1fhveu9dex8ya5f", height: 650 )%>
       <div class="phone-map-container">
         <div style="width: 280px; height: 590px; border-radius: 39px;"
         data-controller="map"
@@ -28,32 +28,32 @@
     <div class="swiper-wrapper">
       <div class="swiper-slide w-100">
         <div class="row flex-wrap justify-content-center align-items-center">
-          <%= image_tag "blow_kisses.png", class: "carousel-img" %>
+          <%= cl_image_tag("a7ocikrch8pwamyp9gbp", class: "carousel-img") %>
           <div class="text-container">
             <h3 class="fw-bold text-white">What is <span class="logo-font fs-2">Ouicity</span>?</h3>
             <p class="fs-5 text-white">We want to bring the joy back to city living! Even though we're all living amongst each other, we
             can still feel at home. Part of being home is working together to keep it beautiful. Our app gets you directly
             involved in your city’s well-being.</p>
           </div>
-          <%= image_tag "right_arrow.png", class: "right-nav-icon" %>
+          <%= cl_image_tag("bjeyw6deg4pwstmrvrij", class: "right-nav-icon") %>
         </div>
       </div>
       <div class="swiper-slide w-100 d-flex flex-column align-items-center">
         <div class="row flex-wrap justify-content-center align-items-center">
-          <%= image_tag "left_arrow.png", class: "left-nav-icon" %>
-          <%= image_tag "man_on_bike.png", class: "carousel-img" %>
+          <%= cl_image_tag("g7aljahndzmcfmxjjstn", class: "left-nav-icon") %>
+          <%= cl_image_tag("hzd9mhng1ngdzg5gq5l1", class: "carousel-img") %>
           <div class="text-container">
             <h3 class="fw-bold text-white">Why use it?</h3>
             <p class="fs-5 text-white">To make your voice heard! Sick of seeing cars parked in the bike lane you use to commute? Let us know!
             We simplify the process and put you in direct contact with your city officials. </p>
           </div>
-          <%= image_tag "right_arrow.png", class: "right-nav-icon" %>
+          <%= cl_image_tag("bjeyw6deg4pwstmrvrij", class: "right-nav-icon") %>
         </div>
       </div>
       <div class="swiper-slide w-100 d-flex flex-column align-items-center">
         <div class="row flex-wrap justify-content-center align-items-center">
-          <%= image_tag "left_arrow.png", class: "left-nav-icon" %>
-          <%= image_tag "paris_worker.png", class: "carousel-img" %>
+          <%= cl_image_tag("g7aljahndzmcfmxjjstn", class: "left-nav-icon")  %>
+          <%= cl_image_tag("ucbxbz7dh6kgr2wdxoun", class: "carousel-img") %>
           <div class="text-container">
             <h3 class="fw-bold text-white">How does it work?</h3>
             <p class="fs-5 text-white">You can identify a specific location where you will then be asked to create an


### PR DESCRIPTION
Hey guys!

I switched to Cloudinary tags for homepage photos which should improve the site load time. I'll be deleting the images from our assets folder _after_ the demo if all goes well.

I also adjusted the image fill for the thumbnails on the alerts#index "listing" (I promise we'll change this name). Now the fill should be proportional (no stretching).

Finally, I removed the carousel buttons if the alert only has one photo, so the user doesn't have an expectation to see other photos that are not there. We can fine-tune this to only show buttons for the amount of photos the alert has, but for now, we'll work with this!

<img width="698" alt="Screen Shot 2022-12-01 at 15 31 58" src="https://user-images.githubusercontent.com/59029920/205079415-a677f7dd-af38-463a-a070-0117a780522e.png">
<img width="730" alt="Screen Shot 2022-12-01 at 15 32 55" src="https://user-images.githubusercontent.com/59029920/205079444-cf71a6da-5255-49e4-8c73-c387fdf03638.png">
