### PR TITLE
fix: fixed alert banner cards to match existing cards.

### DIFF
--- a/app/javascript/controllers/alerts_controller.js
+++ b/app/javascript/controllers/alerts_controller.js
@@ -3,10 +3,11 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["list"];
   connect() {
+
     this.showAlertList();
   }
 
-  showAlertList() {
+  showAlertList(event) {
     this.listTarget.classList.toggle("hidden");
   }
 }

--- a/app/views/alerts/index.html.erb
+++ b/app/views/alerts/index.html.erb
@@ -22,11 +22,16 @@
       </div>
 
       <div class="d-flex justify-content-center mt-4 ">
-        <h5 id="alerts-heading">Alerts in this area</h5>
+        <h5 id="alerts-heading">Most recent alerts</h5>
+        <a data-action="click->alerts#showAlertList"
+        class="fs-3 toggle">
+        <i class="fa-solid fa-circle-chevron-down"></i></a></h5>
       </div>
 
       <div data-alerts-target="list" id="listings" class="listings">
-        <%= render 'shared/alert_banner', alert: alert %>
+        <% @alerts.last(3).each do |alert| %>
+          <%= render 'shared/alert_banner', alert: alert %>
+        <% end %>
       </div>
 
     </div>

--- a/app/views/shared/_alert_banner.html.erb
+++ b/app/views/shared/_alert_banner.html.erb
@@ -1,8 +1,8 @@
 <div class="listing card shadow-sm d-flex flex-row">
-  <%= cl_image_tag(alert.photos[0].key, width: 80, height: 80, class: "rounded-circle", cover: :fill) %>
+  <%= cl_image_tag(alert.photos[0].key, class: "me-3", width: 80, height: 80, radius: :max, input_html: { style: "object-fit:fill;"}) %>
   <div class="listing-details">
-  <%= link_to alert.address, alerts_path(alert) %>
-    <strong>alert.title</strong>
-    <p class="fs-6">alert.description</p>
+  <%= link_to "#{alert.address}", alerts_path(alert) %><br>
+    <strong><%=alert.title %></strong>
+    <p class="fs-6"><%=alert.description%></p>
   </div>
 </div>


### PR DESCRIPTION
I only made a changes to the appears of the cards that we are generating on the view itself to match with what is being generating in our map js controller.

Was not able to have the alerts shown upon opening the page. 