### PR TITLE
fix: added address autocomplete for signup form

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,6 +21,12 @@
       <%= f.input :address,
                   required: true,
                   autofocus: true,
+                  input_html: {autocomplete: "address", data: {address_autocomplete_target: "address"}, class: "d-none"},
+                  wrapper_html: {data: {controller: "address-autocomplete",
+                  address_autocomplete_api_key_value: ENV["MAPBOX_API_KEY"]}} %>
+      <%# <%= f.input :address,
+                  required: true,
+                  autofocus: true,
                   input_html: { autocomplete: "address" }%>
       <%= f.input :password,
                   required: true,


### PR DESCRIPTION
Small fix. Added address autocomplete to user signup form. Doesn't work easily for edit form since the original value is erased. Won't implement it there for now as it's a low priority.