### PR TITLE
fix: added tooltips with category icons also fixed address autocomplete issue

### DIFF
--- a/app/assets/stylesheets/components/_new_alert.scss
+++ b/app/assets/stylesheets/components/_new_alert.scss
@@ -48,8 +48,12 @@
   padding: 20px 0px 20px 0px;
   margin: 10px 0px 10px 0px;
   border: 2px solid #EAEAEA;
-  border-radius: 4px;
+  border-radius: 16px;
   background-color: #FC7D76;
+
+  &:hover {
+    background-color: #fda39e;
+  }
 }
 
 .category-selector:checked + label {

--- a/app/assets/stylesheets/components/_tooltip.scss
+++ b/app/assets/stylesheets/components/_tooltip.scss
@@ -1,0 +1,11 @@
+.tooltip-inner {
+  background-color: white;
+  color: $red;
+  opacity: 1 !important;
+}
+
+.tooltip-arrow::before {
+  background-color: #FBE4E2 !important;
+  opacity: 1 !important;
+  border-bottom-color: white !important;
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -9,3 +9,4 @@
 @import "components/footer";
 @import "components/navbar";
 @import "components/form";
+@import "components/tooltip";

--- a/app/javascript/controllers/address_autocomplete_controller.js
+++ b/app/javascript/controllers/address_autocomplete_controller.js
@@ -11,10 +11,12 @@ export default class extends Controller {
     console.log("connected.")
     this.geocoder = new MapboxGeocoder({
       accessToken: this.apiKeyValue,
-      types: "country,region,place,postcode,locality,neighborhood,address"
+      types: "country,region,place,postcode,locality,neighborhood,address",
+      countries: 'fr'
     })
     this.geocoder.addTo(this.element)
-    this.geocoder.setInput(sessionStorage.getItem("addressEvent"))
+    if (sessionStorage.getItem("addressEvent")){
+      this.geocoder.setInput(sessionStorage.getItem("addressEvent"))}
     this.geocoder.on("result", event => this.#setInputValue(event))
     this.geocoder.on("clear", () => this.#clearInputValue())
     this.geocoder.setPlaceholder("Enter an address...")
@@ -22,13 +24,6 @@ export default class extends Controller {
 
   disconnect() {
     this.geocoder.onRemove()
-  }
-
-  #importInputValue() {
-    if (sessionStorage.getItem("addressEvent")){
-      const storedAddressInput = sessionStorage.getItem("addressEvent")
-      this.addressTarget.value = storedAddressInput
-    }
   }
 
   #setInputValue(event) {

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -22,5 +22,8 @@ application.register("hello", HelloController)
 import MapController from "./map_controller"
 application.register("map", MapController)
 
+import TooltipController from "./tooltip_controller"
+application.register("tooltip", TooltipController)
+
 import TypedJsController from "./typed_js_controller"
 application.register("typed-js", TypedJsController)

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from "@hotwired/stimulus"
+import * as bootstrap from 'bootstrap'
+
+
+// Connects to data-controller="tooltip"
+export default class extends Controller {
+  static targets = ["tooltip"]
+  connect() {
+    console.log("connected.")
+    this.#setTooltip()
+  }
+  #setTooltip() {
+    const categoryItems = document.querySelectorAll("div.category-item")
+    categoryItems.forEach(item => {
+      const category = item.querySelector(".form-check-input").value
+      item.setAttribute('data-bs-toggle','tooltip')
+      item.setAttribute('data-bs-placement','bottom')
+      item.setAttribute('data-bs-title',this.#categoryDefinition(category))
+    })
+    var tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    var tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+  }
+
+  // #insertCloseOnTooltip(){
+  //   const tooltips = document.querySelectorAll("div.tooltip-inner")
+  //   tooltips.forEach(tooltip => {
+  //     tooltip.innerAdjacentHTML('afterbegin', '<i class="fa-solid fa-circle-xmark"></i>')
+  //   })
+  // }
+
+  #categoryDefinition(value) {
+    switch (value) {
+      case "Vandalism" :
+        return "Was a building recently tagged with graffiti? Has someone purposely destroyed public property? "+
+        "If your alert addresses a similar concern, choose vandalism."
+      case "Littering" :
+        return "Choose littering when you see trash in areas where it shouldn't be."
+      case "Infrastructure" :
+        return "The upkeep of our public properties is important. If you notice things that need repair "+
+        " choose infrastructure."
+      case "Transportation" :
+        return "Is there anything happening on the road (besides traffic) that is making it harder or dangerous for you to get from "+
+        "point A to point B? Choose transportation."
+      case "New Idea" :
+        return "Do you have a suggestion for improving the neighborhood? Let us know by choosing new idea."
+      case "Other" :
+        return "Your alert doesn't fit the above categories? No worries! Choose other. "+
+        "We will still review your submission."
+    }
+  }
+}

--- a/app/views/intake/categories/new.html.erb
+++ b/app/views/intake/categories/new.html.erb
@@ -2,13 +2,13 @@
 <h2>Category</h2>
   <div id="inputFields">
         <%= simple_form_for(@category) do |f| %>
-          <div class="form-input">
+          <div class="form-input" data-controller="tooltip">
             <%= f.input :category,
             as: :radio_buttons,
               collection_wrapper_tag: 'div',
               collection_wrapper_class: 'category-wrapper',
               item_wrapper_class: 'category-item',
-              input_html: {class: 'category-selector'},
+              input_html: {class: 'category-selector', data: {tooltip_target: "tooltip"}},
               collection: [
                 ['<i class="fa-solid fa-spray-can fs-1 text-white"></i>'.html_safe,"Vandalism"],
                 ['<i class="fa-solid fa-trash fs-1 text-white"></i>'.html_safe,"Littering"],

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,7 +12,7 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
-          <li class="pt-2 px-2" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Send an alert">
+          <li class="pt-2 px-2">
             <%= link_to new_intake_category_path do %>
               <%= cl_image_tag("jfxjmvn9fxu1j1xnqxra", width:50, height:50) %>
             <% end %>


### PR DESCRIPTION
Not the ideal solution, but I added tooltips to explain the icons. 
I believe the address autocomplete controller was causing some issues with creating an alert if the address wasn't provided on the alerts#index page, but that should be fixed.

<img width="343" alt="Screen Shot 2022-12-05 at 21 59 35" src="https://user-images.githubusercontent.com/59029920/205741768-28ee71bb-8f7e-4d8a-bcd2-1ebc6e42cdb0.png">
