### PR TITLE
Small updates to copy and logo link

### DIFF
--- a/app/views/alerts/_index_resident.html.erb
+++ b/app/views/alerts/_index_resident.html.erb
@@ -22,7 +22,7 @@
                   <% end %>
         !</h3>
         <h4>Can you tell us where the issue is?</h4>
-        <p>Don't see your issue above? <%= link_to "Send an alert.", new_intake_category_path %></p>
+        <p>Don't see your issue listed here? <%= link_to "Send an alert.", new_intake_category_path %></p>
         <div id="geocoder" class="geocoder"
              data-action="submit->map#buildAlertList submit->map#captureSearchResult"></div>
       </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <div class="container-fluid">
-    <%= link_to root_path, class: "d-flex flex-row navbar-brand",
+    <%= link_to alerts_path, class: "d-flex flex-row navbar-brand",
         input_html: {data: {bs_toggle: "offcanvas", bs_target: "#offcanvas"}} do %>
       <%= cl_image_tag("ouicity_logo_j5rhro") %>
       <h2 id="logo" class="ms-3">ouicity</h2>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,10 +1,18 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <div class="container-fluid">
+    <% if user_signed_in? %>
     <%= link_to alerts_path, class: "d-flex flex-row navbar-brand",
         input_html: {data: {bs_toggle: "offcanvas", bs_target: "#offcanvas"}} do %>
       <%= cl_image_tag("ouicity_logo_j5rhro") %>
       <h2 id="logo" class="ms-3">ouicity</h2>
     <% end %>
+    <% else %>
+      <%= link_to root_path, class: "d-flex flex-row navbar-brand",
+        input_html: {data: {bs_toggle: "offcanvas", bs_target: "#offcanvas"}} do %>
+      <%= cl_image_tag("ouicity_logo_j5rhro") %>
+      <h2 id="logo" class="ms-3">ouicity</h2>
+    <% end %>
+      <% end %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Small edits:
- Copy on the /alerts page
--> Changed "Don't see your alert listed above?" to "Don't see your alert listed here?" so that it also makes sense on desktop (where the map is not above)
<img width="439" alt="Screenshot 2022-12-10 at 01 27 05" src="https://user-images.githubusercontent.com/58528404/206818650-1ac165d8-1e0a-4a84-b000-ceb1d6549f8c.png">
- Changed the logo link to land on /alerts after the user is logged in
