### PR TITLE
Fixed a spacing issue between Subscribe and All AAlerts buttons

### DIFF
--- a/app/views/alerts/_show_worker.html.erb
+++ b/app/views/alerts/_show_worker.html.erb
@@ -81,11 +81,15 @@
 
           <%# Subscriptions %>
           <% if @alert.subscribers.find { |s| s.subscriber_id == current_user.id } %>
+            <div>
             <%= link_to "Unsubscribe", subscriber_path(@subscriber), data: {turbo_method: :delete}, class: "btn btn-primary fw-bold text-white" %>
+            </div>
           <% else %>
+          <div>
             <%= simple_form_for [@alert, @subscriber] do |f| %>
-              <%= f.submit "Subscribe", class: "btn btn-primary fw-bold text-white" %>
+              <%= f.submit " Subscribe ", class: "btn btn-primary fw-bold text-white" %>
             <% end %>
+          </div>
           <% end %>
           <%= link_to "All Alerts", alerts_path(), class: "btn btn-primary rounded-3 my-2 fw-bold text-white" %>
 

--- a/app/views/alerts/_show_worker.html.erb
+++ b/app/views/alerts/_show_worker.html.erb
@@ -87,7 +87,7 @@
           <% else %>
           <div>
             <%= simple_form_for [@alert, @subscriber] do |f| %>
-              <%= f.submit " Subscribe ", class: "btn btn-primary fw-bold text-white" %>
+              <%= f.submit "  Subscribe  ", class: "btn btn-primary fw-bold text-white" %>
             <% end %>
           </div>
           <% end %>


### PR DESCRIPTION
Before: the 'All Alert' button moved up next to the 'Subscribe/Unsubscribe' button after clicking it.
<img width="158" alt="Screenshot 2022-12-10 at 15 50 06" src="https://user-images.githubusercontent.com/58528404/206861208-ab09d7f9-74ff-400c-a521-23dde39d3e55.png">
<img width="241" alt="Screenshot 2022-12-10 at 15 50 12" src="https://user-images.githubusercontent.com/58528404/206861211-607b6b16-dc49-4374-b36f-45be0abc06ce.png">


After: it stays on 2 lines
<img width="190" alt="Screenshot 2022-12-10 at 15 49 17" src="https://user-images.githubusercontent.com/58528404/206861215-8cd252ce-6812-4373-86b5-404195bd60aa.png">
<img width="200" alt="Screenshot 2022-12-10 at 15 48 47" src="https://user-images.githubusercontent.com/58528404/206861219-10e84041-a869-4353-b81a-78df4b55a70c.png">

