### PR TITLE
fix: should fix overflow issue on the carousel/easy swiping on mobile

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -24,7 +24,7 @@
 </div>
 
 <div class="carousel-row bg-primary" style=" background-image: var(--bs-gradient);">
-  <div data-controller="carousel" class="swiper-container">
+  <div data-controller="carousel" class="swiper-container" style="overflow-x: hidden;">
     <div class="swiper-wrapper">
       <div class="swiper-slide w-100">
         <div class="row flex-wrap justify-content-center align-items-center">


### PR DESCRIPTION
Hid overflow so that other carousel slides aren't visible (surprised this isn't in the swiper CSS but maybe it is 🤷🏾‍♀️)