### PR TITLE
fix: redirecting worker from homepage to dashboard and preventing resident from accessing worker analytics page

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -81,6 +81,11 @@ class AlertsController < ApplicationController
   end
 
   def analytics
+    if current_user.role != "worker"
+      flash[:alert] = "You are not authorized to view this page."
+      redirect_to root_path
+      flash[:alert]
+    end
     @alerts = Alert.order(created_at: :desc)
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,7 @@ class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: [:home]
 
   def home
+    redirect_to alerts_path if user_signed_in? && current_user.role == "worker"
     @contact = Contact.new
     @alerts = Alert.all
     @markers = @alerts.geocoded.map do |alert|


### PR DESCRIPTION
These are just redirects happening from their respective controllers. They seem to work, but please let me know if you have issues. 