### PR TITLE
Navbar logo redirection before/after authentication

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,18 +1,10 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon sticky-top">
   <div class="container-fluid">
-    <% if user_signed_in? %>
-    <%= link_to alerts_path, class: "d-flex flex-row navbar-brand",
+    <%= link_to user_signed_in? ? alerts_path : root_path, class: "d-flex flex-row navbar-brand",
         input_html: {data: {bs_toggle: "offcanvas", bs_target: "#offcanvas"}} do %>
       <%= cl_image_tag("ouicity_logo_j5rhro") %>
       <h2 id="logo" class="ms-3">ouicity</h2>
     <% end %>
-    <% else %>
-      <%= link_to root_path, class: "d-flex flex-row navbar-brand",
-        input_html: {data: {bs_toggle: "offcanvas", bs_target: "#offcanvas"}} do %>
-      <%= cl_image_tag("ouicity_logo_j5rhro") %>
-      <h2 id="logo" class="ms-3">ouicity</h2>
-    <% end %>
-      <% end %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Used logic to make the navbar logo links more concise and removed 6 lines of repeat code.
But the function is the same:
Not logged in > land on homepage
Logged in > land on /alerts