### PR TITLE
Updated form styling - no more ugly green glow!

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,3 +22,11 @@ body {
   display:flex;
   flex-direction: column;
 }
+
+.valid {
+  border:1px solid rgb(238, 127, 80)
+}
+
+.invalid {
+  border:1px solid rgb(238, 127, 80)
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,11 +22,3 @@ body {
   display:flex;
   flex-direction: column;
 }
-
-.valid {
-  border:1px solid rgb(238, 127, 80)
-}
-
-.invalid {
-  border:1px solid rgb(238, 127, 80)
-}

--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,8 +1,12 @@
 .alert {
-  position: fixed;
-  bottom: 16px;
-  right: 16px;
   z-index: 1000;
+  // width: 100%;
+  background: #E3F3FF;
+  text-align: center;
+  position: fixed;
+  bottom: 100px;
+  right: 50px;
+  // z-index: 1000;
 }
 
 .alerts {

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -1,3 +1,21 @@
 .form-control {
   background-color: white;
 }
+
+:valid.form-control {
+  border-color: rgb(238, 127, 80) !important;
+  box-shadow: inherit !important;
+}
+
+.form-check-label {
+  color: black;
+}
+
+.form-check-input.is-valid ~ .form-check-label {
+  color: black;
+  border-color: rgba(0, 0, 0, 0.25);
+}
+
+.was-validated .form-check-input:valid, .form-check-input.is-valid {
+  border: 1px solid rgba(0, 0, 0, 0.25);
+}

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,14 +1,16 @@
+<div>
 <% if notice %>
-  <div class="alert alert-info alert-dismissible fade show m-1" role="alert">
-    <%= notice %>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
-    </button>
-  </div>
-<% end %>
-<% if alert %>
-  <div class="alert alert-warning alert-dismissible fade show m-1" role="alert">
-    <%= alert %>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
-    </button>
-  </div>
-<% end %>
+    <div class="alert alert-info alert-dismissible fade show m-1" role="alert">
+      <%= notice %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+      </button>
+    </div>
+  <% end %>
+  <% if alert %>
+    <div class="alert alert-warning alert-dismissible fade show m-1" role="alert">
+      <%= alert %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+      </button>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
I was working on the flash alert styling, but I kept getting distracted by the ugly green glow on the forms. 
So I ended up fixing that instead in this branch. Didn't finish the flashes, but did make them match the monkey icon a bit more.

**Before: Ugly green glows**

<img width="484" alt="Screenshot 2022-12-12 at 02 08 06" src="https://user-images.githubusercontent.com/58528404/206941051-93449bec-c488-4b93-9e76-e76680c09c29.png">
<img width="449" alt="Screenshot 2022-12-12 at 02 08 27" src="https://user-images.githubusercontent.com/58528404/206941050-0b8d514f-08d7-48db-b978-1e700f10cdd9.png">

**After: no green except the checkmarks in the form fields to show the input is valid**
(You can also see the light blue flash)

<img width="485" alt="Screenshot 2022-12-12 at 02 07 02" src="https://user-images.githubusercontent.com/58528404/206941115-63f9bce3-112d-484d-a7e2-1b8d722c4a8f.png">
<img width="461" alt="Screenshot 2022-12-12 at 01 30 50" src="https://user-images.githubusercontent.com/58528404/206941118-c239df80-115a-40c0-95b9-d27dcab72613.png">
